### PR TITLE
Replace tokens underscore with hyphen: CY-1262

### DIFF
--- a/src/main/java/codacy/api/CodacyClient.java
+++ b/src/main/java/codacy/api/CodacyClient.java
@@ -44,6 +44,9 @@ public class CodacyClient {
     public <T> T genericRequest(String requestType, String endpoint,
                                 Class<T> responseType, HashMap<String, String> parameters) throws CodacyGenericException {
         parameters.put(Endpoints.API_TOKEN, this.apiToken);
+        // This is deprecated and is kept for backward compatibility. It will be
+        // removed in the context of CY-1272
+        parameters.put(Endpoints.LEGACY_API_TOKEN, this.apiToken);
         String response = null;
         Gson gson = new Gson();
 

--- a/src/main/java/codacy/api/request/Endpoints.java
+++ b/src/main/java/codacy/api/request/Endpoints.java
@@ -2,9 +2,12 @@ package codacy.api.request;
 
 public class Endpoints {
 
-    public final static String API = "/2.0";
+    public static final String API = "/2.0";
 
-    public final static String API_TOKEN = "api_token";
+    public static final String API_TOKEN = "api-token";
+    // This is deprecated and is kept for backward compatibility. It will be
+    // removed in the context of CY-1272
+    public static final String LEGACY_API_TOKEN = "api_token";
 
     public static String commit(String username, String projectName, String commitUUID) {
         return API + "/" + username + "/" + projectName + "/commit/" + commitUUID;


### PR DESCRIPTION
The problem is nginx, used in k8s, by default drops all http request headers that contain the underscore char, meaning that project_token and api_token headers are not reaching the route handlers and these are failing on the authentication step.

Therefore we are changing the API tokens to use "-" instead of "_".

More context in bitbucket.org/qamine/codacy-website/pull-requests/3185
